### PR TITLE
Add SQL LIMIT clause support

### DIFF
--- a/pkg/openobserve/sqlparser.go
+++ b/pkg/openobserve/sqlparser.go
@@ -4,12 +4,13 @@ import (
 	"fmt"
 	"strings"
 
+	"regexp"
+
 	"github.com/auxten/postgresql-parser/pkg/sql/parser"
 	"github.com/auxten/postgresql-parser/pkg/sql/sem/tree"
 	"github.com/auxten/postgresql-parser/pkg/walk"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 	"github.com/xwb1989/sqlparser"
-	"regexp"
 )
 
 const (
@@ -30,6 +31,7 @@ type SQL struct {
 	selectColumns  []string
 	whereVariables []string
 	CompletedSql   string
+	Limit          int64 // Extracted LIMIT value from SQL, 0 means no limit specified
 }
 
 const (
@@ -150,11 +152,15 @@ func (sp *SqlParser) ParseSql(sqlStr string) (*SQL, error) {
 		return nil, err
 	}
 
+	// Extract LIMIT value from SQL using sqlparser (more reliable for LIMIT extraction)
+	limitValue := extractLimitFromSql(sqlStr)
+
 	if len(selectedColumns) == 1 && selectedColumns[0] == "*" {
 		return &SQL{
 			selectMode:     SqlSelectALlColumns,
 			selectColumns:  selectedColumns,
 			whereVariables: whereVariables,
+			Limit:          limitValue,
 		}, nil
 	}
 
@@ -162,6 +168,7 @@ func (sp *SqlParser) ParseSql(sqlStr string) (*SQL, error) {
 		selectMode:     SqlSelectSpecifiedcColumns,
 		selectColumns:  selectedColumns,
 		whereVariables: whereVariables,
+		Limit:          limitValue,
 	}, nil
 }
 
@@ -227,4 +234,42 @@ func (v *Visitor) VisitPre(expr tree.Expr) (recurse bool, newExpr tree.Expr) {
 func (v *Visitor) VisitPost(expr tree.Expr) (newNode tree.Expr) {
 	// return expr
 	return nil
+}
+
+// extractLimitFromSql extracts the LIMIT value from SQL string using sqlparser
+func extractLimitFromSql(sqlStr string) int64 {
+	stmt, err := sqlparser.Parse(sqlStr)
+	if err != nil {
+		return 0 // Return 0 if parsing fails (means no limit or invalid SQL)
+	}
+
+	selectStmt, ok := stmt.(*sqlparser.Select)
+	if !ok {
+		return 0 // Not a SELECT statement
+	}
+
+	if selectStmt.Limit == nil {
+		return 0 // No LIMIT clause
+	}
+
+	// LIMIT can be: LIMIT n or LIMIT offset, n
+	// Rowcount is the second value if both present, or the only value if only one
+	if selectStmt.Limit.Rowcount == nil {
+		return 0
+	}
+
+	// Try to extract numeric value from the expression
+	// The Rowcount is an Expr, which could be a number or expression
+	// We'll try to convert it to string first, then parse as int
+	limitStr := sqlparser.String(selectStmt.Limit.Rowcount)
+
+	// Parse the string as int64
+	var limitValue int64
+	_, err = fmt.Sscanf(limitStr, "%d", &limitValue)
+	if err != nil {
+		log.DefaultLogger.Warn("extractLimitFromSql: Failed to parse LIMIT value", "limitStr", limitStr, "error", err)
+		return 0
+	}
+
+	return limitValue
 }


### PR DESCRIPTION
## Overview

Added SQL `LIMIT` clause support for controlling result set size

---

### Problem

Previously, the plugin ignored the `LIMIT` clause in SQL queries and always used a hardcoded default of 200 results. This meant that queries like `SELECT * FROM services LIMIT 1000` would still only return 200 logs, making it impossible for users to retrieve larger result sets.

### Solution

This PR implements automatic extraction of the `LIMIT` clause from SQL queries and uses it to set the `Size` parameter in OpenObserve API requests.

## Key Changes

1. **SQL LIMIT Extraction** (`pkg/openobserve/sqlparser.go`):
   - Added `Limit` field to `SQL` struct to store extracted LIMIT value
   - Implemented `extractLimitFromSql()` function that parses SQL using `sqlparser` to extract LIMIT values
   - Handles both `LIMIT n` and `LIMIT offset, n` syntax
   - Returns 0 if no LIMIT clause is present

2. **Size Parameter Logic** (`pkg/plugin/queryhandler.go`):
   - Updated `prepareSearchRequest()` to parse SQL and extract LIMIT value
   - Priority order for determining size:
     1. Frontend `Size` parameter (if explicitly set)
     2. SQL `LIMIT` clause value
     3. Default of 200
   - Added safety cap of 10,000 to prevent browser crashes
   - Logs warning if requested limit exceeds maximum

## Features

- ✅ Automatic LIMIT extraction from SQL queries
- ✅ Supports direct LIMIT values: `LIMIT 1000`
- ✅ Supports template variables: `LIMIT ${limit_var}`
- ✅ Safety cap at 10,000 rows to prevent browser crashes
- ✅ Backward compatible: defaults to 200 if no LIMIT specified
- ✅ Works with both Dashboard and Explore queries

## Testing

Tested with:
- `LIMIT 500` → Returns 500 logs ✅
- `LIMIT 1000` → Returns 1000 logs ✅
- `LIMIT 5000` → Returns up to 5000 logs (capped at 10,000) ✅
- `LIMIT ${limit}` → Uses template variable value ✅
- No LIMIT → Defaults to 200 ✅

## Impact

- **Breaking Changes**: None
- **Backward Compatibility**: Fully maintained

## Example Usage
The Logs panel:
```
SELECT *
FROM services
WHERE time_range(_timestamp, '${__from:date:iso}', '${__to:date:iso}')
  AND (
    (length('${trace_id:text}') > 0 AND trace_id = '${trace_id:text}')
    OR
    (length('${trace_id:text}') = 0
      AND service_name IN ([[service_name:singlequote]])
      AND service_version IN ([[service_version:singlequote]])
      AND region IN ([[region:singlequote]])
      AND cluster_id IN ([[cluster_id:singlequote]])
      AND cell_id IN ([[cell_id:singlequote]])
      AND k8s_node_name IN ([[k8s_node_name:singlequote]])
      AND k8s_pod_name IN ([[k8s_pod_name:singlequote]])
      AND env IN ([[env:singlequote]])
      AND severity IN ([[severity:singlequote]])
      AND body LIKE '%$search_term%'
    )
  )
ORDER BY _timestamp DESC
LIMIT ${limit}
```

<img width="1616" height="930" alt="image" src="https://github.com/user-attachments/assets/5aea96c1-02f4-4fd0-9316-6c88d3acda15" />

## Related Issues

Fixes #5
